### PR TITLE
Fix ImageError

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,5 +8,5 @@ export default nextAuth.auth;
 
 export const config = {
   // https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher
-  matcher: ["/((?!api|_next/static|_next/image|.png).*)"],
+  matcher: ["/((?!api|_next/static|_next/image|customers|.png).*)"],
 };


### PR DESCRIPTION
- Fix middleware.ts to exclude customers route from next-auth middleware 

https://stackoverflow.com/questions/76286726/nextjs-imageerror-unable-to-optimize-image-and-unable-to-fallback-to-upstream-i
```
ImageError: Unable to optimize image and unable to fallback to upstream image
    at imageOptimizer (/Users/shunusami/Desktop/42/nextjs-dashboard/node_modules/next/dist/server/image-optimizer.js:659:19)
    at async cacheEntry.imageResponseCache.get.incrementalCache (/Users/shunusami/Desktop/42/nextjs-dashboard/node_modules/next/dist/server/next-server.js:176:65)
    at async /Users/shunusami/Desktop/42/nextjs-dashboard/node_modules/next/dist/server/response-cache/index.js:93:36
    at async /Users/shunusami/Desktop/42/nextjs-dashboard/node_modules/next/dist/lib/batcher.js:41:32 {
  statusCode: 400
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated URL matching configuration to exclude "customers" path, improving the accuracy of URL path matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->